### PR TITLE
Add a rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,22 @@
+tab_spaces = 4
+
+edition = "2024"
+style_edition = "2024"
+
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+
+trailing_semicolon = true
+overflow_delimited_expr = true
+struct_lit_single_line = true
+
+enum_discrim_align_threshold = 20
+struct_field_align_threshold = 20
+
+hex_literal_case = "Lower"
+
+# Comments
+wrap_comments = true
+comment_width = 80
+format_code_in_doc_comments = true
+doc_comment_code_block_width = 80


### PR DESCRIPTION
- `tab_spaces = 4`
- [`imports_granularity`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#imports_granularity) merges imports by module
- [`group_imports`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#group_imports) groups imports by `std`, external and crate
- [`trailing_semicolon`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#trailing_semicolon) forces semicolons after `return`, `break` and `continue` statements
- [`struct_lit_single_line`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#struct_lit_single_line) allows for struct initialization in one line, when under 18 characters
- [`enum_discrim_align_threshold`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#enum_discrim_align_threshold) and [`struct_field_align_threshold`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#struct_field_align_threshold) allows vertically aligning fields / enum variants up to 20 characters
- Comments are wrapped after 80 characters

Closes #6 